### PR TITLE
update button to accept the url

### DIFF
--- a/src/components/ArticlePreview/index.tsx
+++ b/src/components/ArticlePreview/index.tsx
@@ -22,7 +22,7 @@ export const ArticlePreview = ({ article }: { article: Article }) => {
                 group
             "
         >
-            <Link href={`/articles/${article.id}`} className="text-2xl font-normal mb-2 block">
+            <Link to={`/articles/${article.id}`} className="text-2xl font-normal mb-2 block">
                 {article.title}
             </Link>
 
@@ -32,7 +32,7 @@ export const ArticlePreview = ({ article }: { article: Article }) => {
 
             {body}
 
-            <Link href={`/articles/${article.id}`} className="inline-block mt-2">Читать далее</Link>
+            <Link to={`/articles/${article.id}`} className="inline-block mt-2">Читать далее</Link>
 
             <div className="w-full flex items-center justify-center pt-6 pb-0 group-last:hidden">
                 <Ellipsis />

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -53,10 +53,15 @@ interface Props {
     children: ReactNode,
     onClick?: () => void,
     type?: keyof typeof ButtonTypes,
+    to?: string,
 }
 
-export const Button = ({ type = 'default', children, onClick }: Props) => (
-    <button className={`${ButtonTypes[type]}`} onClick={onClick}>
-        {children}
-    </button>
-)
+export const Button = ({ type = 'default', children, to, onClick }: Props) => {
+    const Tag = to ? 'a' : 'button';
+
+    return (
+        <Tag className={`${ButtonTypes[type]}`} href={to} onClick={onClick}>
+            {children}
+        </Tag>
+    );
+};

--- a/src/components/EditorArticlePreview/index.tsx
+++ b/src/components/EditorArticlePreview/index.tsx
@@ -5,7 +5,7 @@ import { Link } from '../Link';
 
 export const EditorArticlePreview = ({ article, onRemove }: { article: Article, onRemove: (id: string) => void }) => (
     <div className="w-full p-4 mt-2 gap-2 flex flex-col rounded border">
-        <Link className="text-black" href={`/editor/${article.id}`}>
+        <Link className="text-black" to={`/editor/${article.id}`}>
             {article.title}
         </Link>
 
@@ -14,8 +14,8 @@ export const EditorArticlePreview = ({ article, onRemove }: { article: Article, 
         </div>
 
         <div className="flex flex-row gap-2 text-xs">
-            <Link className="text-blue-400" href={`/editor/${article.id}`}>Редактировать</Link> ·
-            <Link className="text-blue-400" href={`/articles/${article.id}`}>Просмотр</Link> ·
+            <Link className="text-blue-400" to={`/editor/${article.id}`}>Редактировать</Link> ·
+            <Link className="text-blue-400" to={`/articles/${article.id}`}>Просмотр</Link> ·
             <Link className="text-red-400" onClick={() => onRemove(article.id)}>Удалить</Link>
         </div>
     </div>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -13,8 +13,8 @@ interface Props {
     onSearch?: (text: string) => void,
 }
 
-const LinkButtonWithIcon = ({ href, children, color = 'bg-black-500' }: { children: ReactNode, color: string, href: string }) => (
-    <Link className={cx('w-8 h-8 flex items-center justify-center rounded', color)} href={href}>
+const LinkButtonWithIcon = ({ to, children, color = 'bg-black-500' }: { children: ReactNode, color: string, to: string }) => (
+    <Link className={cx('w-8 h-8 flex items-center justify-center rounded', color)} to={to}>
         {children}
     </Link>
 );
@@ -30,20 +30,20 @@ export const Header = ({ onSearch = () => { } }: Props) => {
         <Section>
             <Row className="w-full px-4 py-2 uppercase text-gray-600 flex justify-between items-center">
                 <div className="flex gap-4">
-                    <Link className="text-xs uppercase" href="/">Статьи</Link>
-                    <Link className="text-xs uppercase" href="/">Связаться c нами</Link>
+                    <Link className="text-xs uppercase" to="/">Статьи</Link>
+                    <Link className="text-xs uppercase" to="/">Связаться c нами</Link>
                 </div>
 
                 <div className="flex gap-4">
-                    <LinkButtonWithIcon href={links.vk} color="bg-blue-500">
+                    <LinkButtonWithIcon to={links.vk} color="bg-blue-500">
                         <VK size={14} />
                     </LinkButtonWithIcon>
 
-                    <LinkButtonWithIcon href={links.youtube} color="bg-red-500">
+                    <LinkButtonWithIcon to={links.youtube} color="bg-red-500">
                         <YouTube size={14} />
                     </LinkButtonWithIcon>
 
-                    <LinkButtonWithIcon href={links.instagram} color="bg-blue-500">
+                    <LinkButtonWithIcon to={links.instagram} color="bg-blue-500">
                         <Instagram size={14} />
                     </LinkButtonWithIcon>
 

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 
 
 interface PropsWithHref {
-    href: string,
+    to: string,
     target?: '_self' | '_blank',
 }
 

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -16,7 +16,7 @@ const Page = () => (
             </div>
             <div className="flex items-center justify-center w-full h-full">
                 <h1 className="text-2xl font-extrabold text-slate-900 border-r pr-5">404</h1>
-                <h2 className="text-slate-700 ml-5">Такой страницы не существует. <Link className="text-blue-600" href="/">Домой?</Link></h2>
+                <h2 className="text-slate-700 ml-5">Такой страницы не существует. <Link className="text-blue-600" to="/">Домой?</Link></h2>
             </div>
         </div>
     </>

--- a/src/pages/editor/[...id].tsx
+++ b/src/pages/editor/[...id].tsx
@@ -66,7 +66,7 @@ export const Page = () => {
     };
 
     return (
-        <div className="max-w-4xl mx-auto mb-4">
+        <div className="max-w-4xl w-full mx-auto mb-4">
             <div className="flex justify-between items-center p-2 pt-4">
                 {state && (
                     <div className="text-sm text-gray-600">

--- a/src/pages/editor/index.tsx
+++ b/src/pages/editor/index.tsx
@@ -6,6 +6,7 @@ import { EditorArticlePreview } from '@/components/EditorArticlePreview';
 import { ConfirmationModal } from '@/components/ConfirmationModal';
 import { authOptions } from '@/pages/api/auth/[...nextauth]';
 import { Article } from '@/types';
+import { Button } from '@/components/Button';
 
 
 const Page = () => {
@@ -54,6 +55,12 @@ const Page = () => {
             </ConfirmationModal>
 
             <div className="flex flex-col max-w-4xl w-full mx-auto p-4">
+                <div className="flex justify-end items-center pb-4">
+                    <Button type="secondary" to="/editor/new">
+                        Новая статья
+                    </Button>
+                </div>
+
                 {articles.map((article) => (
                     <EditorArticlePreview
                         key={article.id}


### PR DESCRIPTION
now button and link both accept `to` prop (former `href`).

if `to` passed to button, it acts like link.

such changes made to avoid putting links into button and to provide button experience to button styled links